### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- publish token
+- remove publish
+- remove publish
+- remove publish
+- remove publish
+
+### Other
+
+- Merge pull request [#26](https://github.com/ruslanti/test_release_2/pull/26) from ruslanti/test3422
+- release
+- Merge pull request [#19](https://github.com/ruslanti/test_release_2/pull/19) from ruslanti/test2
+- add ignore
+- add ignore
+- Merge pull request [#12](https://github.com/ruslanti/test_release_2/pull/12) from ruslanti/feat/release_4
+- Merge pull request [#10](https://github.com/ruslanti/test_release_2/pull/10) from ruslanti/feat/new_release_1
+- Initial commit
+
+## [0.1.1](https://github.com/ruslanti/test_release_2/releases/tag/v0.1.1) - 2024-09-09
+
+### Added
+
+- add changelog
+- re-init
+- 7 attempt of release
+- 6 attempt of release
+- 4 attempt of release
+- 3 attempt of release
+- second attempt of release
+- first release
+- first version
+
+### Fixed
+
 - remove publish
 - remove publish
 - remove publish


### PR DESCRIPTION
## 🤖 New release
* `test_release_2`: 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).